### PR TITLE
Fix off-by-one SSID array access

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,7 +369,7 @@ void connectToNetwork() {
   if (logging) {
     writeFile(SPIFFS, "/error.log", "Connecting to Network: \n");
   }
-  for (int i = 0; i <= ssidArrNo; i++) {
+  for (int i = 0; i < ssidArrNo; i++) {
     ssid = ssidArr[i].c_str();
     Serial.print("SSID name: ");
     Serial.print(ssidArr[i]);


### PR DESCRIPTION
When none of the SSID names work, the loop will read outside the list of SSID names because of an off-by-one loop condition. This is the fix.