### PR TITLE
remove unnesessary bme280 library, change wire initialization

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,5 +20,5 @@ lib_deps =
    arduino-libraries/ArduinoHttpClient @ 0.4.0
    ldab/esp32_ftpclient @ 0.1.3
    claws/BH1750 @ 1.1.4
+   adafruit/Adafruit Unified Sensor @ 1.1.4
    adafruit/DHT sensor library @ 1.4.0
-   adafruit/Adafruit BME280 Library @ 2.1.2


### PR DESCRIPTION
The bme280.begin() was needed because the Wire could not initialize before power switched on for the sensors.  
The explicit 'Adafruit Unified Sensor' dependency was needed to compile using Clion with platformio plugin.  