### PR TITLE
Add "°" in the Temp entities

### DIFF
--- a/Autodiscovery/TTGO-T-HIGrow-aut.py
+++ b/Autodiscovery/TTGO-T-HIGrow-aut.py
@@ -96,7 +96,7 @@ def send_discovery_topics(msg):
         }, 
         'temp': {
             'name': f"{d['plant']['sensorname']} Temperature",
-            'unit_of_meas': "C", 
+            'unit_of_meas': "°C", 
             'icon':'mdi:thermometer'
         }, 
         'humid': {
@@ -111,7 +111,7 @@ def send_discovery_topics(msg):
         }, 
         'soilTemp': {
             'name': f"{d['plant']['sensorname']} SoilTemp",
-            'unit_of_meas': "C", 
+            'unit_of_meas': "°C", 
             'icon':'mdi:thermometer'
         },
         'salt': {


### PR DESCRIPTION
Home assistant will auto convert from °C to °F and back, etc. if the unit of measurement is formatted correctly.  I've added the "°" to allow this.